### PR TITLE
fixed substring error when the JAR entry is the WEB_JAR_PREFIX

### DIFF
--- a/src/main/java/bathe/BatheBooter.java
+++ b/src/main/java/bathe/BatheBooter.java
@@ -244,6 +244,9 @@ public class BatheBooter {
           String name = entry.getName();
 
           if (entry.isDirectory()) {
+            //stop problem where the WEB_JAR_PREFIX/WEB_CLASSES_PREFIX is included as an entry
+            if (name.equals(WEB_JAR_PREFIX) || name.equals(WEB_CLASSES_PREFIX)) continue;
+
             if (name.startsWith(WEB_JAR_PREFIX)) {
               String partName = name.substring(webJarLength);
 


### PR DESCRIPTION
As discussed, getting the stack trace:
Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String index out of range: -1
    at java.lang.String.substring(String.java:1911)
    at bathe.BatheBooter.determineJarOffsets(BatheBooter.java:250)
    at bathe.BatheBooter.run(BatheBooter.java:112)
    at bathe.BatheBooter.main(BatheBooter.java:103)

Debugging indicates that some zip implementations were including WEB_JAR_PREFIX as an entry, which was not expected.
